### PR TITLE
Add BigInt64 and BigUint64 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Allocates a typed array (or ArrayBuffer) with at least n elements.
   + `"arraybuffer"`
   + `"data"`
   + `"uint8_clamped"`
+  + `"bigint64"`
+  + `"biguint64"`
   + `"buffer"`
 
 **Returns** A typed array with at least `n` elements in it.  If `dtype` is undefined, an ArrayBuffer is returned.
@@ -66,6 +68,8 @@ Allocates a typed array (or ArrayBuffer) with at least n elements.
 * `pool.mallocArrayBuffer`
 * `pool.mallocDataView`
 * `pool.mallocUint8Clamped`
+* `pool.mallocBigInt64`
+* `pool.mallocBigUint64`
 * `pool.mallocBuffer`
 
 ### `pool.free(array)`
@@ -86,6 +90,8 @@ Returns the array back to the pool.
 * `pool.freeArrayBuffer`
 * `pool.freeDataView`
 * `pool.freeUint8Clamped`
+* `pool.freeBigInt64`
+* `pool.freeBigUint64`
 * `pool.freeBuffer`
 
 ### `pool.clearCache()`

--- a/pool.js
+++ b/pool.js
@@ -6,26 +6,36 @@ var dup = require('dup')
 //Legacy pool support
 if(!global.__TYPEDARRAY_POOL) {
   global.__TYPEDARRAY_POOL = {
-      UINT8   : dup([32, 0])
-    , UINT16  : dup([32, 0])
-    , UINT32  : dup([32, 0])
-    , INT8    : dup([32, 0])
-    , INT16   : dup([32, 0])
-    , INT32   : dup([32, 0])
-    , FLOAT   : dup([32, 0])
-    , DOUBLE  : dup([32, 0])
-    , DATA    : dup([32, 0])
-    , UINT8C  : dup([32, 0])
-    , BUFFER  : dup([32, 0])
+      UINT8     : dup([32, 0])
+    , UINT16    : dup([32, 0])
+    , UINT32    : dup([32, 0])
+    , BIGUINT64 : dup([32, 0])
+    , INT8      : dup([32, 0])
+    , INT16     : dup([32, 0])
+    , INT32     : dup([32, 0])
+    , BIGINT64  : dup([32, 0])
+    , FLOAT     : dup([32, 0])
+    , DOUBLE    : dup([32, 0])
+    , DATA      : dup([32, 0])
+    , UINT8C    : dup([32, 0])
+    , BUFFER    : dup([32, 0])
   }
 }
 
 var hasUint8C = (typeof Uint8ClampedArray) !== 'undefined'
+var hasBigUint64 = (typeof BigUint64Array) !== 'undefined'
+var hasBigInt64 = (typeof BigInt64Array) !== 'undefined'
 var POOL = global.__TYPEDARRAY_POOL
 
 //Upgrade pool
 if(!POOL.UINT8C) {
   POOL.UINT8C = dup([32, 0])
+}
+if(!POOL.BIGUINT64) {
+  POOL.BIGUINT64 = dup([32, 0])
+}
+if(!POOL.BIGINT64) {
+  POOL.BIGINT64 = dup([32, 0])
 }
 if(!POOL.BUFFER) {
   POOL.BUFFER = dup([32, 0])
@@ -67,9 +77,11 @@ function freeTypedArray(array) {
 exports.freeUint8 =
 exports.freeUint16 =
 exports.freeUint32 =
+exports.freeBigUint64 =
 exports.freeInt8 =
 exports.freeInt16 =
 exports.freeInt32 =
+exports.freeBigInt64 =
 exports.freeFloat32 = 
 exports.freeFloat =
 exports.freeFloat64 = 
@@ -108,6 +120,10 @@ exports.malloc = function malloc(n, dtype) {
         return mallocDouble(n)
       case 'uint8_clamped':
         return mallocUint8Clamped(n)
+      case 'bigint64':
+        return mallocBigInt64(n)
+      case 'biguint64':
+        return mallocBigUint64(n)
       case 'buffer':
         return mallocBuffer(n)
       case 'data':
@@ -181,6 +197,24 @@ function mallocUint8Clamped(n) {
 }
 exports.mallocUint8Clamped = mallocUint8Clamped
 
+function mallocBigUint64(n) {
+  if(hasBigUint64) {
+    return new BigUint64Array(mallocArrayBuffer(8*n), 0, n)
+  } else {
+    return null;
+  }
+}
+exports.mallocBigUint64 = mallocBigUint64
+
+function mallocBigInt64(n) {
+  if (hasBigInt64) {
+    return new BigInt64Array(mallocArrayBuffer(8*n), 0, n)
+  } else {
+    return null;
+  }
+}
+exports.mallocBigInt64 = mallocBigInt64
+
 function mallocDataView(n) {
   return new DataView(mallocArrayBuffer(n), 0, n)
 }
@@ -207,6 +241,8 @@ exports.clearCache = function clearCache() {
     POOL.INT32[i].length = 0
     POOL.FLOAT[i].length = 0
     POOL.DOUBLE[i].length = 0
+    POOL.BIGUINT64[i].length = 0
+    POOL.BIGINT64[i].length = 0
     POOL.UINT8C[i].length = 0
     DATA[i].length = 0
     BUFFER[i].length = 0

--- a/test/test.js
+++ b/test/test.js
@@ -72,6 +72,24 @@ require("tape")("typedarray-pool", function(t) {
     t.assert(a.length >= i)
     pool.free(a)
 
+    a = pool.malloc(i, "bigint64")
+    if((typeof BigInt64Array) !== "undefined") {
+        t.assert(a instanceof BigInt64Array, "bigint64")
+    } else {
+        t.assert(a instanceof BigInt64Array, "bigint64 defaults to null")
+    }
+    t.assert(a.length >= i)
+    pool.free(a)
+
+    a = pool.malloc(i, "biguint64")
+    if((typeof BigUint64Array) !== "undefined") {
+        t.assert(a instanceof BigUint64Array, "biguint64")
+    } else {
+        t.assert(a instanceof BigUint64Array, "biguint64 defaults to null")
+    }
+    t.assert(a.length >= i)
+    pool.free(a)
+
     a = pool.malloc(i, "buffer")
     t.assert(Buffer.isBuffer(a), "buffer")
     t.assert(a.length >= i)
@@ -144,6 +162,24 @@ require("tape")("typedarray-pool", function(t) {
     }
     t.assert(a.length >= i)
     pool.freeUint8Clamped(a)
+
+    a = pool.mallocBigInt64(i)
+    if((typeof BigInt64Array) !== "undefined") {
+        t.assert(a instanceof BigInt64Array, "bigint64")
+    } else {
+        t.equal(a, null, "bigint64 defaults null")
+    }
+    t.assert(a.length >= i)
+    pool.freeBigInt64(a)
+
+    a = pool.mallocBigUint64(i)
+    if((typeof BigUint64Array) !== "undefined") {
+        t.assert(a instanceof BigUint64Array, "biguint64")
+    } else {
+        t.equal(a, null, "bigint64 defaults null")
+    }
+    t.assert(a.length >= i)
+    pool.freeBigUint64(a)
 
     a = pool.mallocBuffer(i)
     t.assert(Buffer.isBuffer(a), "buffer")


### PR DESCRIPTION
This PR adds support for BigInt64Array and BigUint64Array. It's mostly analogous to Uint8ClampedArray, with the exception that it does *not* fall back to anything if not available. There are a couple bits of logic I'm a little uncertain on. Notes below.

Related: https://github.com/scijs/ndarray/pull/43