### PR TITLE
using self instead of global if not defined

### DIFF
--- a/pool.js
+++ b/pool.js
@@ -5,6 +5,7 @@ var dup = require('dup')
 var Buffer = require('buffer').Buffer
 
 //Legacy pool support
+var global = global || self;
 if(!global.__TYPEDARRAY_POOL) {
   global.__TYPEDARRAY_POOL = {
       UINT8     : dup([32, 0])


### PR DESCRIPTION
When running in web worker context no `global` variable is available, instead `self` is used. Current error: `UncaughtReferenceError: global is not defined`.