### PR TITLE
Add buffer as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "bit-twiddle": "^1.0.0",
+    "buffer": "^6.0.0",
     "dup": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #9 

The buffer module only exists in Node environments. In webpack <5, the node system modules were shimmed. In webpack 5+, node system modules are not shimmed. This should really be a dependency either way and not rely on webpack shimming node system modules