### PR TITLE
convert global -> globalThis and remove Buffer support. fixes #13, #3, #12, #9

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ Allocates a typed array (or ArrayBuffer) with at least n elements.
   + `"uint8_clamped"`
   + `"bigint64"`
   + `"biguint64"`
-  + `"buffer"`
 
 **Returns** A typed array with at least `n` elements in it.  If `dtype` is undefined, an ArrayBuffer is returned.
 
@@ -70,7 +69,6 @@ Allocates a typed array (or ArrayBuffer) with at least n elements.
 * `pool.mallocUint8Clamped`
 * `pool.mallocBigInt64`
 * `pool.mallocBigUint64`
-* `pool.mallocBuffer`
 
 ### `pool.free(array)`
 Returns the array back to the pool.
@@ -92,7 +90,6 @@ Returns the array back to the pool.
 * `pool.freeUint8Clamped`
 * `pool.freeBigInt64`
 * `pool.freeBigUint64`
-* `pool.freeBuffer`
 
 ### `pool.clearCache()`
 Removes all references to cached arrays.  Use this when you are done with the pool to return all the cached memory to the garbage collector.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dup": "^1.0.0"
   },
   "devDependencies": {
-    "tape": "^2.12.3"
+    "tape": "^5.9.0"
   },
   "scripts": {
     "test": "tape test/*.js"

--- a/pool.js
+++ b/pool.js
@@ -2,7 +2,6 @@
 
 var bits = require('bit-twiddle')
 var dup = require('dup')
-var Buffer = require('buffer').Buffer
 
 //Legacy pool support
 if(!globalThis.__TYPEDARRAY_POOL) {
@@ -19,7 +18,6 @@ if(!globalThis.__TYPEDARRAY_POOL) {
     , DOUBLE    : dup([32, 0])
     , DATA      : dup([32, 0])
     , UINT8C    : dup([32, 0])
-    , BUFFER    : dup([32, 0])
   }
 }
 
@@ -38,18 +36,12 @@ if(!POOL.BIGUINT64) {
 if(!POOL.BIGINT64) {
   POOL.BIGINT64 = dup([32, 0])
 }
-if(!POOL.BUFFER) {
-  POOL.BUFFER = dup([32, 0])
-}
 
-//New technique: Only allocate from ArrayBufferView and Buffer
+//New technique: Only allocate from ArrayBufferView
 var DATA    = POOL.DATA
-  , BUFFER  = POOL.BUFFER
 
 exports.free = function free(array) {
-  if(Buffer.isBuffer(array)) {
-    BUFFER[bits.log2(array.length)].push(array)
-  } else {
+  
     if(Object.prototype.toString.call(array) !== '[object ArrayBuffer]') {
       array = array.buffer
     }
@@ -59,7 +51,6 @@ exports.free = function free(array) {
     var n = array.length || array.byteLength
     var log_n = bits.log2(n)|0
     DATA[log_n].push(array)
-  }
 }
 
 function freeArrayBuffer(buffer) {
@@ -92,10 +83,6 @@ exports.freeDataView = freeTypedArray
 
 exports.freeArrayBuffer = freeArrayBuffer
 
-exports.freeBuffer = function freeBuffer(array) {
-  BUFFER[bits.log2(array.length)].push(array)
-}
-
 exports.malloc = function malloc(n, dtype) {
   if(dtype === undefined || dtype === 'arraybuffer') {
     return mallocArrayBuffer(n)
@@ -125,8 +112,6 @@ exports.malloc = function malloc(n, dtype) {
         return mallocBigInt64(n)
       case 'biguint64':
         return mallocBigUint64(n)
-      case 'buffer':
-        return mallocBuffer(n)
       case 'data':
       case 'dataview':
         return mallocDataView(n)
@@ -221,16 +206,6 @@ function mallocDataView(n) {
 }
 exports.mallocDataView = mallocDataView
 
-function mallocBuffer(n) {
-  n = bits.nextPow2(n)
-  var log_n = bits.log2(n)
-  var cache = BUFFER[log_n]
-  if(cache.length > 0) {
-    return cache.pop()
-  }
-  return new Buffer(n)
-}
-exports.mallocBuffer = mallocBuffer
 
 exports.clearCache = function clearCache() {
   for(var i=0; i<32; ++i) {
@@ -246,6 +221,5 @@ exports.clearCache = function clearCache() {
     POOL.BIGINT64[i].length = 0
     POOL.UINT8C[i].length = 0
     DATA[i].length = 0
-    BUFFER[i].length = 0
   }
 }

--- a/pool.js
+++ b/pool.js
@@ -5,8 +5,8 @@ var dup = require('dup')
 var Buffer = require('buffer').Buffer
 
 //Legacy pool support
-if(!global.__TYPEDARRAY_POOL) {
-  global.__TYPEDARRAY_POOL = {
+if(!globalThis.__TYPEDARRAY_POOL) {
+  globalThis.__TYPEDARRAY_POOL = {
       UINT8     : dup([32, 0])
     , UINT16    : dup([32, 0])
     , UINT32    : dup([32, 0])
@@ -26,7 +26,7 @@ if(!global.__TYPEDARRAY_POOL) {
 var hasUint8C = (typeof Uint8ClampedArray) !== 'undefined'
 var hasBigUint64 = (typeof BigUint64Array) !== 'undefined'
 var hasBigInt64 = (typeof BigInt64Array) !== 'undefined'
-var POOL = global.__TYPEDARRAY_POOL
+var POOL = globalThis.__TYPEDARRAY_POOL
 
 //Upgrade pool
 if(!POOL.UINT8C) {

--- a/test/test.js
+++ b/test/test.js
@@ -89,11 +89,6 @@ require("tape")("typedarray-pool", function(t) {
     }
     t.assert(a.length >= i)
     pool.free(a)
-
-    a = pool.malloc(i, "buffer")
-    t.assert(Buffer.isBuffer(a), "buffer")
-    t.assert(a.length >= i)
-    pool.free(a)
     
     a = pool.malloc(i)
     t.assert(a instanceof ArrayBuffer, "array buffer")
@@ -180,11 +175,6 @@ require("tape")("typedarray-pool", function(t) {
     }
     t.assert(a.length >= i)
     pool.freeBigUint64(a)
-
-    a = pool.mallocBuffer(i)
-    t.assert(Buffer.isBuffer(a), "buffer")
-    t.assert(a.length >= i)
-    pool.freeBuffer(a)
     
     a = pool.mallocArrayBuffer(i)
     t.assert(a instanceof ArrayBuffer, "array buffer")


### PR DESCRIPTION
@mikolalysenko  `globalThis` is well supported now, node v12+ and all major browsers.

This will require a major version bump since it's breaking support for pre node v12.